### PR TITLE
안드로이드 테스트 코드 수정

### DIFF
--- a/core/common/src/main/java/co/kr/mvisample/common/utils/CustomOffset.kt
+++ b/core/common/src/main/java/co/kr/mvisample/common/utils/CustomOffset.kt
@@ -1,7 +1,0 @@
-package co.kr.mvisample.common.utils
-
-import androidx.compose.ui.semantics.SemanticsPropertyKey
-import androidx.compose.ui.semantics.SemanticsPropertyReceiver
-
-val CustomOffsetYKey = SemanticsPropertyKey<Int>("customOffsetY")
-var SemanticsPropertyReceiver.customOffsetY by CustomOffsetYKey

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     implementation(libs.androidx.runner)
     
     implementation(libs.androidx.paging.compose)
+    implementation(libs.androidx.ui.test.junit4.android)
 }

--- a/core/testing/src/main/java/co/kr/mvisample/testing/utils/hasPrefixContentDescription.kt
+++ b/core/testing/src/main/java/co/kr/mvisample/testing/utils/hasPrefixContentDescription.kt
@@ -1,0 +1,16 @@
+package co.kr.mvisample.testing.utils
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+
+fun hasPrefixContentDescription(
+    prefix: String = "pokemonIcon_",
+): SemanticsMatcher {
+    return SemanticsMatcher(
+        "ContentDescription starts with $prefix"
+    ) { semanticsNode ->
+        val descriptions = semanticsNode.config.getOrNull(SemanticsProperties.ContentDescription)
+        descriptions?.any { desc -> desc.startsWith(prefix) } == true
+    }
+}

--- a/core/testing/src/main/java/co/kr/mvisample/testing/utils/hasPrefixContentDescription.kt
+++ b/core/testing/src/main/java/co/kr/mvisample/testing/utils/hasPrefixContentDescription.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 
 fun hasPrefixContentDescription(
-    prefix: String = "pokemonIcon_",
+    prefix: String,
 ): SemanticsMatcher {
     return SemanticsMatcher(
         "ContentDescription starts with $prefix"
@@ -16,7 +16,7 @@ fun hasPrefixContentDescription(
 }
 
 fun hasSuffixContentDescription(
-    suffix: String = "pokemonIcon_",
+    suffix: String,
 ): SemanticsMatcher {
     return SemanticsMatcher(
         "ContentDescription ends with $suffix"

--- a/core/testing/src/main/java/co/kr/mvisample/testing/utils/hasPrefixContentDescription.kt
+++ b/core/testing/src/main/java/co/kr/mvisample/testing/utils/hasPrefixContentDescription.kt
@@ -14,3 +14,14 @@ fun hasPrefixContentDescription(
         descriptions?.any { desc -> desc.startsWith(prefix) } == true
     }
 }
+
+fun hasSuffixContentDescription(
+    suffix: String = "pokemonIcon_",
+): SemanticsMatcher {
+    return SemanticsMatcher(
+        "ContentDescription ends with $suffix"
+    ) { semanticsNode ->
+        val descriptions = semanticsNode.config.getOrNull(SemanticsProperties.ContentDescription)
+        descriptions?.any { desc -> desc.endsWith(suffix) } == true
+    }
+}

--- a/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
+++ b/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
@@ -1,12 +1,36 @@
 package co.kr.mvisample.testing.utils
 
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 
 fun AndroidComposeTestRule<*, *>.waitUntilAssert(
     node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteraction,
     assert: SemanticsNodeInteraction.() -> Unit,
     action: SemanticsNodeInteraction.() -> Unit = {},
+    timeoutMillis: Long = 2_000L
+) {
+    val targetNode = this.node()
+
+    waitUntil (
+        timeoutMillis = timeoutMillis,
+        condition = {
+            try {
+                targetNode.assert()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+    )
+
+    targetNode.action()
+}
+
+fun AndroidComposeTestRule<*, *>.waitUntilAssertAll(
+    node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteractionCollection,
+    assert: SemanticsNodeInteractionCollection.() -> Unit,
+    action: SemanticsNodeInteractionCollection.() -> Unit = {},
     timeoutMillis: Long = 2_000L
 ) {
     val targetNode = this.node()

--- a/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
+++ b/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
@@ -27,10 +27,9 @@ fun AndroidComposeTestRule<*, *>.waitUntilAssert(
     targetNode.action()
 }
 
-fun AndroidComposeTestRule<*, *>.waitUntilAssertAll(
+fun AndroidComposeTestRule<*, *>.waitUntilAllNodesAsserted(
     node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteractionCollection,
     assert: SemanticsNodeInteractionCollection.() -> Unit,
-    action: SemanticsNodeInteractionCollection.() -> Unit = {},
     timeoutMillis: Long = 2_000L
 ) {
     val targetNode = this.node()
@@ -46,6 +45,28 @@ fun AndroidComposeTestRule<*, *>.waitUntilAssertAll(
             }
         }
     )
+}
 
-    targetNode.action()
+fun AndroidComposeTestRule<*, *>.waitUntilNodeAssertedAndAction(
+    node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteractionCollection,
+    assert: SemanticsNodeInteractionCollection.() -> SemanticsNodeInteraction,
+    action: SemanticsNodeInteraction.() -> Unit = {},
+    timeoutMillis: Long = 2_000L
+) {
+    val targetNode = this.node()
+    var semanticsNodeInteraction: SemanticsNodeInteraction? = null
+
+    waitUntil (
+        timeoutMillis = timeoutMillis,
+        condition = {
+            try {
+                semanticsNodeInteraction = targetNode.assert()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+    )
+
+    semanticsNodeInteraction?.action()
 }

--- a/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
+++ b/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
@@ -8,7 +8,7 @@ fun AndroidComposeTestRule<*, *>.waitUntilAssert(
     node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteraction,
     assert: SemanticsNodeInteraction.() -> Unit,
     action: SemanticsNodeInteraction.() -> Unit = {},
-    timeoutMillis: Long = 2_000L
+    timeoutMillis: Long = 5_000L
 ) {
     val targetNode = this.node()
 
@@ -30,7 +30,7 @@ fun AndroidComposeTestRule<*, *>.waitUntilAssert(
 fun AndroidComposeTestRule<*, *>.waitUntilAllNodesAsserted(
     node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteractionCollection,
     assert: SemanticsNodeInteractionCollection.() -> Unit,
-    timeoutMillis: Long = 2_000L
+    timeoutMillis: Long = 5_000L
 ) {
     val targetNode = this.node()
 
@@ -51,7 +51,7 @@ fun AndroidComposeTestRule<*, *>.waitUntilNodeAssertedAndAction(
     node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteractionCollection,
     assert: SemanticsNodeInteractionCollection.() -> SemanticsNodeInteraction,
     action: SemanticsNodeInteraction.() -> Unit = {},
-    timeoutMillis: Long = 2_000L
+    timeoutMillis: Long = 5_000L
 ) {
     val targetNode = this.node()
     var semanticsNodeInteraction: SemanticsNodeInteraction? = null

--- a/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
+++ b/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
@@ -1,0 +1,27 @@
+package co.kr.mvisample.testing.utils
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+
+fun AndroidComposeTestRule<*, *>.waitUntilAssert(
+    node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteraction,
+    assert: SemanticsNodeInteraction.() -> Unit,
+    action: SemanticsNodeInteraction.() -> Unit = {},
+    timeoutMillis: Long = 2_000L
+) {
+    val targetNode = this.node()
+
+    waitUntil (
+        timeoutMillis = timeoutMillis,
+        condition = {
+            try {
+                targetNode.assert()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+    )
+
+    targetNode.action()
+}

--- a/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
+++ b/core/testing/src/main/java/co/kr/mvisample/testing/utils/waitUntilAssert.kt
@@ -10,13 +10,11 @@ fun AndroidComposeTestRule<*, *>.waitUntilAssert(
     action: SemanticsNodeInteraction.() -> Unit = {},
     timeoutMillis: Long = 5_000L
 ) {
-    val targetNode = this.node()
-
     waitUntil (
         timeoutMillis = timeoutMillis,
         condition = {
             try {
-                targetNode.assert()
+                node().assert()
                 true
             } catch (e: AssertionError) {
                 false
@@ -24,7 +22,7 @@ fun AndroidComposeTestRule<*, *>.waitUntilAssert(
         }
     )
 
-    targetNode.action()
+    node().action()
 }
 
 fun AndroidComposeTestRule<*, *>.waitUntilAllNodesAsserted(
@@ -32,13 +30,11 @@ fun AndroidComposeTestRule<*, *>.waitUntilAllNodesAsserted(
     assert: SemanticsNodeInteractionCollection.() -> Unit,
     timeoutMillis: Long = 5_000L
 ) {
-    val targetNode = this.node()
-
     waitUntil (
         timeoutMillis = timeoutMillis,
         condition = {
             try {
-                targetNode.assert()
+                node().assert()
                 true
             } catch (e: AssertionError) {
                 false
@@ -53,14 +49,13 @@ fun AndroidComposeTestRule<*, *>.waitUntilNodeAssertedAndAction(
     action: SemanticsNodeInteraction.() -> Unit = {},
     timeoutMillis: Long = 5_000L
 ) {
-    val targetNode = this.node()
     var semanticsNodeInteraction: SemanticsNodeInteraction? = null
 
     waitUntil (
         timeoutMillis = timeoutMillis,
         condition = {
             try {
-                semanticsNodeInteraction = targetNode.assert()
+                semanticsNodeInteraction = node().assert()
                 true
             } catch (e: AssertionError) {
                 false

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(projects.core.testing)
 
     testImplementation(libs.junit)
 

--- a/feature/src/androidTest/java/co/kr/mvisample/feature/computer/ComputerScreenTest.kt
+++ b/feature/src/androidTest/java/co/kr/mvisample/feature/computer/ComputerScreenTest.kt
@@ -4,18 +4,18 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.Density
-import co.kr.mvisample.common.utils.CustomOffsetYKey
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import co.kr.mvisample.design.PreviewPokemonTheme
 import co.kr.mvisample.feature.R
 import co.kr.mvisample.feature.home.computer.ComputerScreen
-import co.kr.mvisample.feature.home.computer.yOffset
 import co.kr.mvisample.testing.HiltTestActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -37,7 +37,7 @@ class ComputerScreenTest {
     lateinit var density: Density
 
     @Before
-    fun setUp() {
+    fun 테스트준비() {
         hiltRule.inject()
 
         composeTestRule.setContent {
@@ -49,65 +49,99 @@ class ComputerScreenTest {
     }
 
     @Test
-    fun 포켓몬아이콘이_초기화면에_보인다() {
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(6))
-            .assertIsDisplayed()
-
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(9))
-            .assertIsDisplayed()
+    fun 포켓몬아이콘이_초기화면에_보인다() = runTest {
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(getPokemonIcon(6, dpToInt(0.dp))) },
+            assert = { assertIsDisplayed() }
+        )
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(getPokemonIcon(9, dpToInt(0.dp))) },
+            assert = { assertIsDisplayed() }
+        )
     }
 
     @Test
     fun 리자몽을_누른후_offset이_변경되는지_확인한다() = runTest {
-        println(getPokemonIcon(6))
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(6))
-            .performClick()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(getPokemonIcon(6, dpToInt(0.dp))) },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule.waitForIdle()
-
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(6))
-            .assert(SemanticsMatcher.expectValue(CustomOffsetYKey, with(density) { yOffset.roundToPx().times(-1) }))
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(getPokemonIcon(6, dpToInt((-8).dp))) },
+            assert = { assertIsDisplayed() }
+        )
     }
 
     @Test
     fun 리자몽을_누른후_다시_리자몽을_누른다() = runTest {
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(6))
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(getPokemonIcon(6, dpToInt(0.dp))) },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
+
+        composeTestRule.onNode(hasPrefixContentDescription("pokemonIcon_6_"))
             .performClick()
 
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(6))
-            .performClick()
-
-        composeTestRule.waitForIdle()
-
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(6))
-            .assert(SemanticsMatcher.expectValue(CustomOffsetYKey, 0))
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(getPokemonIcon(6, dpToInt(0.dp))) },
+            assert = { assertIsDisplayed() }
+        )
     }
 
     @Test
     fun 리자몽을_누른후_거북왕을_누른다() = runTest {
-        val before = getCurrentPokemonOrder()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(getPokemonIcon(6, dpToInt(0.dp))) },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(6))
-            .performClick()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(getPokemonIcon(9, dpToInt(0.dp))) },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule
-            .onNodeWithContentDescription(getPokemonIcon(9))
-            .performClick()
-
-        composeTestRule.waitForIdle()
-
-        val after = getCurrentPokemonOrder()
-        assert(before != after)
-        assert(before.sorted() == after.sorted())
+        composeTestRule.waitUntil {
+            val pokemonDescriptions = getPokemonDescriptions()
+            pokemonDescriptions.size == 2 &&
+                pokemonDescriptions[0] == getPokemonIcon(9, dpToInt(0.dp)) &&
+                pokemonDescriptions[1] == getPokemonIcon(6, dpToInt(0.dp))
+        }
     }
+
+    private fun dpToInt(dp: Dp) = with (density) { dp.roundToPx() }
+
+    private fun AndroidComposeTestRule<*, *>.waitUntilAssert(
+        node: AndroidComposeTestRule<*, *>.() -> SemanticsNodeInteraction,
+        assert: SemanticsNodeInteraction.() -> Unit,
+        action: SemanticsNodeInteraction.() -> Unit = {},
+        timeoutMillis: Long = 2_000L
+    ) {
+        val targetNode = this.node()
+
+        waitUntil (
+            timeoutMillis = timeoutMillis,
+            condition = {
+                try {
+                    targetNode.assert()
+                    true
+                } catch (e: AssertionError) {
+                    false
+                }
+            }
+        )
+
+        targetNode.action()
+    }
+
+    private fun getPokemonDescriptions(): List<String> =
+        composeTestRule.onAllNodes(hasPrefixContentDescription())
+            .fetchSemanticsNodes()
+            .mapNotNull { it.config.getOrNull(SemanticsProperties.ContentDescription)?.firstOrNull() }
 
     private fun hasPrefixContentDescription(
         prefix: String = "pokemonIcon_",
@@ -120,10 +154,5 @@ class ComputerScreenTest {
         }
     }
 
-    private fun getCurrentPokemonOrder(): List<String> =
-        composeTestRule.onAllNodes(hasPrefixContentDescription())
-            .fetchSemanticsNodes()
-            .mapNotNull { it.config.getOrNull(SemanticsProperties.ContentDescription)?.firstOrNull() }
-
-    private fun getPokemonIcon(id: Int) = activity.getString(R.string.pokemon_icon, id)
+    private fun getPokemonIcon(id: Int, offsetY: Int) = activity.getString(R.string.pokemon_icon, id, offsetY)
 }

--- a/feature/src/androidTest/java/co/kr/mvisample/feature/detail/DetailScreenTest.kt
+++ b/feature/src/androidTest/java/co/kr/mvisample/feature/detail/DetailScreenTest.kt
@@ -2,7 +2,6 @@ package co.kr.mvisample.feature.detail
 
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -14,6 +13,8 @@ import co.kr.mvisample.design.PreviewPokemonTheme
 import co.kr.mvisample.feature.R
 import co.kr.mvisample.feature.detail.presentation.DetailViewModel
 import co.kr.mvisample.testing.HiltTestActivity
+import co.kr.mvisample.testing.utils.waitUntilAssert
+import co.kr.mvisample.testing.utils.waitUntilAssertAll
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
@@ -29,7 +30,6 @@ class DetailScreenTest {
 
     @get:Rule(order = 1)
     val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
-    val activity get() = composeTestRule.activity
 
     private lateinit var viewModel: DetailViewModel
 
@@ -38,10 +38,19 @@ class DetailScreenTest {
     private var isDetailScreen = true
 
     @Before
-    fun setUp() {
+    fun 테스트준비() {
         hiltRule.inject()
 
-        initViewModel()
+        viewModel = DetailViewModel(
+            pokemonRepository = pokemonRepository,
+            savedStateHandle = SavedStateHandle(
+                mapOf(
+                    DetailViewModel.ID to 6,
+                    DetailViewModel.NAME to "charizard",
+                    DetailViewModel.IS_DISCOVERED to true,
+                )
+            )
+        )
 
         composeTestRule.setContent {
             PreviewPokemonTheme {
@@ -55,52 +64,49 @@ class DetailScreenTest {
 
     @Test
     fun 포켓몬상세정보를_불러온다() {
-        composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_detail_image))
-            .assertIsDisplayed()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(activity.getString(R.string.pokemon_detail_image)) },
+            assert = { assertIsDisplayed() }
+        )
 
-        composeTestRule
-            .onAllNodesWithText("charizard")
-            .assertCountEquals(2)
+        composeTestRule.waitUntilAssertAll(
+            node = { onAllNodesWithText("charizard") },
+            assert = { assertCountEquals(2) }
+        )
 
-        composeTestRule
-            .onNodeWithText("006")
-            .assertIsDisplayed()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("006") },
+            assert = { assertIsDisplayed() }
+        )
 
-        composeTestRule
-            .onNodeWithText("90.5 KG")
-            .assertIsDisplayed()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("90.5 KG") },
+            assert = { assertIsDisplayed() }
+        )
 
-        composeTestRule
-            .onNodeWithText("1.7 M")
-            .assertIsDisplayed()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("1.7 M") },
+            assert = { assertIsDisplayed() }
+        )
 
-        composeTestRule
-            .onNodeWithText("fire\nflying")
-            .isDisplayed()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("fire\nflying") },
+            assert = { assertIsDisplayed() }
+        )
     }
 
     @Test
     fun 뒤로가기를_누른다() {
-        composeTestRule
-            .onNodeWithContentDescription("backIcon")
-            .performClick()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription("backIcon") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntil(
+            timeoutMillis = 2000L
+        ) {
             isDetailScreen.not()
         }
-    }
-
-    private fun initViewModel() {
-        viewModel = DetailViewModel(
-            pokemonRepository = pokemonRepository,
-            savedStateHandle = SavedStateHandle(
-                mapOf(
-                    DetailViewModel.ID to 6,
-                    DetailViewModel.NAME to "charizard",
-                    DetailViewModel.IS_DISCOVERED to true,
-                )
-            )
-        )
     }
 }

--- a/feature/src/androidTest/java/co/kr/mvisample/feature/detail/DetailScreenTest.kt
+++ b/feature/src/androidTest/java/co/kr/mvisample/feature/detail/DetailScreenTest.kt
@@ -13,8 +13,8 @@ import co.kr.mvisample.design.PreviewPokemonTheme
 import co.kr.mvisample.feature.R
 import co.kr.mvisample.feature.detail.presentation.DetailViewModel
 import co.kr.mvisample.testing.HiltTestActivity
+import co.kr.mvisample.testing.utils.waitUntilAllNodesAsserted
 import co.kr.mvisample.testing.utils.waitUntilAssert
-import co.kr.mvisample.testing.utils.waitUntilAssertAll
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
@@ -69,7 +69,7 @@ class DetailScreenTest {
             assert = { assertIsDisplayed() }
         )
 
-        composeTestRule.waitUntilAssertAll(
+        composeTestRule.waitUntilAllNodesAsserted(
             node = { onAllNodesWithText("charizard") },
             assert = { assertCountEquals(2) }
         )

--- a/feature/src/androidTest/java/co/kr/mvisample/feature/detail/DetailScreenTest.kt
+++ b/feature/src/androidTest/java/co/kr/mvisample/feature/detail/DetailScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.lifecycle.SavedStateHandle
 import co.kr.mvisample.data.repository.PokemonRepository
 import co.kr.mvisample.design.PreviewPokemonTheme
@@ -91,7 +92,7 @@ class DetailScreenTest {
 
         composeTestRule.waitUntilAssert(
             node = { onNodeWithText("fire\nflying") },
-            assert = { assertIsDisplayed() }
+            assert = { performScrollTo().assertIsDisplayed() }
         )
     }
 

--- a/feature/src/androidTest/java/co/kr/mvisample/feature/pokedex/PokedexScreenTest.kt
+++ b/feature/src/androidTest/java/co/kr/mvisample/feature/pokedex/PokedexScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import co.kr.mvisample.design.PreviewPokemonTheme
 import co.kr.mvisample.feature.R
 import co.kr.mvisample.feature.home.pokedex.PokedexScreen
@@ -56,7 +57,7 @@ class PokedexScreenTest {
                 onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
                     .onChildren()
            },
-            assert = { onFirst().assertIsDisplayed() },
+            assert = { onFirst().performScrollTo().assertIsDisplayed() },
             action = { performClick() }
         )
 
@@ -73,7 +74,7 @@ class PokedexScreenTest {
                 onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
                     .onChildren()
             },
-            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().assertIsDisplayed() },
+            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
             action = { performClick() }
         )
 
@@ -99,7 +100,7 @@ class PokedexScreenTest {
                 onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
                     .onChildren()
             },
-            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().assertIsDisplayed() },
+            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
             action = { performClick() }
         )
 
@@ -131,7 +132,7 @@ class PokedexScreenTest {
                 onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
                     .onChildren()
             },
-            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().assertIsDisplayed() },
+            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
             action = { performClick() }
         )
 
@@ -169,7 +170,7 @@ class PokedexScreenTest {
                 onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
                     .onChildren()
             },
-            assert = { onFirst().assertIsDisplayed() }
+            assert = { onFirst().performScrollTo().assertIsDisplayed() }
         )
 
         composeTestRule.waitUntilAssert(

--- a/feature/src/androidTest/java/co/kr/mvisample/feature/pokedex/PokedexScreenTest.kt
+++ b/feature/src/androidTest/java/co/kr/mvisample/feature/pokedex/PokedexScreenTest.kt
@@ -3,6 +3,7 @@ package co.kr.mvisample.feature.pokedex
 import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onChildren
@@ -74,7 +75,7 @@ class PokedexScreenTest {
                 onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
                     .onChildren()
             },
-            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
+            assert = { filter(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
             action = { performClick() }
         )
 
@@ -100,7 +101,7 @@ class PokedexScreenTest {
                 onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
                     .onChildren()
             },
-            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
+            assert = { filter(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
             action = { performClick() }
         )
 
@@ -132,7 +133,7 @@ class PokedexScreenTest {
                 onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
                     .onChildren()
             },
-            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
+            assert = { filter(hasPrefixContentDescription("isDiscover is false")).onFirst().performScrollTo().assertIsDisplayed() },
             action = { performClick() }
         )
 

--- a/feature/src/androidTest/java/co/kr/mvisample/feature/pokedex/PokedexScreenTest.kt
+++ b/feature/src/androidTest/java/co/kr/mvisample/feature/pokedex/PokedexScreenTest.kt
@@ -1,12 +1,9 @@
 package co.kr.mvisample.feature.pokedex
 
-import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasContentDescription
-import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onFirst
@@ -17,6 +14,11 @@ import co.kr.mvisample.design.PreviewPokemonTheme
 import co.kr.mvisample.feature.R
 import co.kr.mvisample.feature.home.pokedex.PokedexScreen
 import co.kr.mvisample.testing.HiltTestActivity
+import co.kr.mvisample.testing.utils.hasPrefixContentDescription
+import co.kr.mvisample.testing.utils.hasSuffixContentDescription
+import co.kr.mvisample.testing.utils.waitUntilAllNodesAsserted
+import co.kr.mvisample.testing.utils.waitUntilAssert
+import co.kr.mvisample.testing.utils.waitUntilNodeAssertedAndAction
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.test.runTest
@@ -35,7 +37,7 @@ class PokedexScreenTest {
     val activity get() = composeTestRule.activity
 
     @Before
-    fun setUp() {
+    fun 테스트준비() {
         hiltRule.inject()
 
         composeTestRule.setContent {
@@ -49,199 +51,137 @@ class PokedexScreenTest {
 
     @Test
     fun 포켓몬이름을_클릭한다() = runTest {
-        waitUntil {
-            composeTestRule
-                .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-                .onChildren()
-                .onFirst()
-                .isDisplayed()
-        }
+        composeTestRule.waitUntilNodeAssertedAndAction(
+            node = {
+                onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
+                    .onChildren()
+           },
+            assert = { onFirst().assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-            .onChildren()
-            .onFirst()
-            .performClick()
-
-        composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_image))
-            .assertIsDisplayed()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithContentDescription(activity.getString(R.string.pokemon_image)) },
+            assert = { assertIsDisplayed() }
+        )
     }
 
     @Test
     fun 발견하기를_클릭한다() = runTest {
-        waitUntil {
-            composeTestRule
-                .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-                .onChildren()
-                .onFirst()
-                .isDisplayed()
-        }
+        composeTestRule.waitUntilNodeAssertedAndAction(
+            node = {
+                onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
+                    .onChildren()
+            },
+            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-            .onChildren()
-            .onFirst()
-            .performClick()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("발견하기") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule
-            .onNodeWithText("발견하기")
-            .performClick()
-
-        composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-            .onChildren()
-            .assertAny(hasText("bulbasaur"))
+        composeTestRule.waitUntilAllNodesAsserted(
+            node = {
+                onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
+                    .onChildren()
+            },
+            assert = { assertAny(hasPrefixContentDescription("isDiscover is true")) },
+        )
     }
 
     @Test
     fun 포획하기를_클릭한다() = runTest {
-        waitUntil {
-            composeTestRule
-                .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-                .onChildren()
-                .onFirst()
-                .isDisplayed()
-        }
+        composeTestRule.waitUntilNodeAssertedAndAction(
+            node = {
+                onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
+                    .onChildren()
+            },
+            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-            .onChildren()
-            .onFirst()
-            .performClick()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("발견하기") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        val node = composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-            .onChildren()
-            .onFirst()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("포획하기") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        if (node.containTextExactly("???")) {
-            composeTestRule
-                .onNodeWithText("발견하기")
-                .performClick()
-        }
-
-        waitUntil {
-            composeTestRule
-                .onNodeWithText("포획하기")
-                .isDisplayed()
-        }
-
-        composeTestRule
-            .onNodeWithText("포획하기")
-            .performClick()
-
-        waitUntil {
-            val node = composeTestRule
-                .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-                .onChildren()
-                .onFirst()
-                .fetchSemanticsNode()
-
-            hasContentDescription(activity.getString(R.string.pokeball, true.toString())).matches(node)
-        }
+        composeTestRule.waitUntilAllNodesAsserted(
+            node = {
+                onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
+                    .onChildren()
+            },
+            assert = { assertAny(hasContentDescription("isDiscover is true and isCaught is true")) },
+        )
     }
 
     @Test
     fun 놓아주기를_클릭한다() = runTest {
-        waitUntil {
-            composeTestRule
-                .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-                .onChildren()
-                .onFirst()
-                .isDisplayed()
-        }
+        composeTestRule.waitUntilNodeAssertedAndAction(
+            node = {
+                onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
+                    .onChildren()
+            },
+            assert = { assertAny(hasPrefixContentDescription("isDiscover is false")).onFirst().assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-            .onChildren()
-            .onFirst()
-            .performClick()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("발견하기") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        val node = composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-            .onChildren()
-            .onFirst()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("포획하기") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        if (node.containTextExactly("???")) {
-            composeTestRule
-                .onNodeWithText("발견하기")
-                .performClick()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("놓아주기") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-            waitUntil {
-                composeTestRule
-                    .onNodeWithText("포획하기")
-                    .isDisplayed()
-            }
-
-            composeTestRule
-                .onNodeWithText("포획하기")
-                .performClick()
-
-            waitUntil {
-                composeTestRule
-                    .onNodeWithText("놓아주기")
-                    .isDisplayed()
-            }
-
-            composeTestRule
-                .onNodeWithText("놓아주기")
-                .performClick()
-        } else {
-            waitUntil {
-                composeTestRule
-                    .onNodeWithText("놓아주기")
-                    .isDisplayed()
-            }
-
-            composeTestRule
-                .onNodeWithText("놓아주기")
-                .performClick()
-        }
-
-        waitUntil {
-            val node = composeTestRule
-                .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-                .onChildren()
-                .onFirst()
-                .fetchSemanticsNode()
-
-            hasContentDescription(activity.getString(R.string.pokeball, false.toString())).matches(node)
-        }
+        composeTestRule.waitUntilAllNodesAsserted(
+            node = {
+                onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
+                    .onChildren()
+            },
+            assert = { assertAll(hasSuffixContentDescription("isCaught is false")) },
+        )
     }
 
     @Test
     fun 선택된_포켓몬이_없을때_발견하기를_클릭한다() = runTest {
-        waitUntil {
-            composeTestRule
-                .onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
-                .onChildren()
-                .onFirst()
-                .isDisplayed()
-        }
+        composeTestRule.waitUntilNodeAssertedAndAction(
+            node = {
+                onNodeWithContentDescription(activity.getString(R.string.pokemon_name_list))
+                    .onChildren()
+            },
+            assert = { onFirst().assertIsDisplayed() }
+        )
 
-        composeTestRule
-            .onNodeWithText("발견하기")
-            .performClick()
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("발견하기") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
+        )
 
-        composeTestRule
-            .onNodeWithText("선택된 포켓몬이 없습니다.")
-            .assertIsDisplayed()
-    }
-
-    private fun SemanticsNodeInteraction.containTextExactly(expected: String): Boolean {
-        return try {
-            this.assertTextContains(expected)
-            true
-        } catch (e: AssertionError) {
-            false
-        }
-    }
-
-    private fun waitUntil(condition: () -> Boolean) {
-        composeTestRule.waitUntil(
-            timeoutMillis = 5000L,
-            condition = condition
+        composeTestRule.waitUntilAssert(
+            node = { onNodeWithText("선택된 포켓몬이 없습니다.") },
+            assert = { assertIsDisplayed() },
+            action = { performClick() }
         )
     }
 }

--- a/feature/src/main/java/co/kr/mvisample/feature/detail/Detail.kt
+++ b/feature/src/main/java/co/kr/mvisample/feature/detail/Detail.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Text
@@ -68,7 +70,10 @@ fun DetailScreen(
         errorContent = uiState.error.errorContent,
         onSendAction = viewModel::handleBasicDialogAction
     ) {
-        Column {
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+        ) {
             DetailHeader(
                 pokemonDetail = uiState.content.pokemonDetail,
                 onBackClick = { viewModel.handleAction(DetailAction.OnBackClick) }

--- a/feature/src/main/java/co/kr/mvisample/feature/home/computer/Computer.kt
+++ b/feature/src/main/java/co/kr/mvisample/feature/home/computer/Computer.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -33,7 +32,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.kr.mvisample.common.components.OverlayWithLoadingAndDialog
 import co.kr.mvisample.common.components.pokemonCard
-import co.kr.mvisample.common.utils.customOffsetY
 import co.kr.mvisample.design.PokemonTheme
 import co.kr.mvisample.feature.R
 import co.kr.mvisample.feature.home.computer.model.ComputerAction
@@ -121,8 +119,7 @@ private fun PokemonIconGrid(
                         this.scaleX = scaleX
                         this.scaleY = scaleY
                     }
-                    .animateItem()
-                    .semantics { customOffsetY = offset.y },
+                    .animateItem(),
                 painter = rememberAsyncImagePainter(
                     model = ImageRequest.Builder(context)
                         .data(pokemon.iconUrl)
@@ -133,7 +130,7 @@ private fun PokemonIconGrid(
                         }
                         .build()
                 ),
-                contentDescription = stringResource(R.string.pokemon_icon, pokemon.id)
+                contentDescription = stringResource(R.string.pokemon_icon, pokemon.id, offset.y)
             )
         }
     }

--- a/feature/src/main/java/co/kr/mvisample/feature/home/pokedex/Pockdex.kt
+++ b/feature/src/main/java/co/kr/mvisample/feature/home/pokedex/Pockdex.kt
@@ -262,7 +262,8 @@ private fun PokemonListItem(
                 width = if (isSelected) 1.dp else 0.dp,
                 color = if (isSelected) Color.White else Color.Transparent
             )
-            .clickable { onClickPokemon(pokemon) },
+            .clickable { onClickPokemon(pokemon) }
+            .semantics { contentDescription = "isDiscover is ${pokemon.isDiscovered} and isCaught is ${pokemon.isCaught}" },
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (pokemon.isDiscovered) {
@@ -301,8 +302,6 @@ private fun Pokeball(
     outlineColor: Color = PokemonTheme.colors.basicText,
     centerCircleColor: Color = Color.White
 ) {
-    val context = LocalContext.current
-
     val animatedTopColor by animateColorAsState(
         targetValue = if (isCaught) caughtColorTop else uncaughtColorTop,
         animationSpec = tween(durationMillis = 300),
@@ -319,9 +318,6 @@ private fun Pokeball(
         modifier = modifier
             .size(16.dp)
             .border(1.dp, color = outlineColor, shape = CircleShape)
-            .semantics {
-                contentDescription = context.getString(R.string.pokeball, isCaught.toString())
-            }
     ) {
         val diameter = size.minDimension
         val radius = diameter / 2

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -4,5 +4,5 @@
     <string name="pokemon_image">pokemonImage</string>
     <string name="pokeball">pokeball_%s</string>
     <string name="pokemon_detail_image">pokemonDetailImage</string>
-    <string name="pokemon_icon">pokemonIcon_%d</string>
+    <string name="pokemon_icon">pokemonIcon_%d_%d</string>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="pokemon_name_list">pokemonNameList</string>
     <string name="pokemon_image">pokemonImage</string>
-    <string name="pokeball">pokeball_%s</string>
     <string name="pokemon_detail_image">pokemonDetailImage</string>
     <string name="pokemon_icon">pokemonIcon_%d_%d</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ room = "2.6.1"
 kotestVersion = "5.9.0"
 turbine = "1.2.0"
 runner = "1.6.2"
+uiTestJunit4Android = "1.7.0-beta02"
 
 [libraries]
 
@@ -67,6 +68,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxComposeNavigation" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
+androidx-ui-test-junit4-android = { group = "androidx.compose.ui", name = "ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
 
 # coroutine for test
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }


### PR DESCRIPTION
## 상세내용
기존 테스트에서 assertIsDisplayed() 등 즉시 검증을 수행하던 부분을, waitUntil 기반 확장 함수로 변경

서버 응답으로 노출되는 컴포저블에 대한 검증 안정성을 높이기 위한 변경

새로 도입한 유틸은 타임아웃 내에서 조건을 polling하면서 기다린 후 검증 및 액션을 수행